### PR TITLE
Add additional SVG shape types

### DIFF
--- a/docs/TODOLIST.md
+++ b/docs/TODOLIST.md
@@ -2,7 +2,7 @@
 
 ## 1. Structure des types et du store
 
-- [ ] Définir les types TypeScript pour toutes les formes SVG (ellipse, cercle, ligne, polygone, texte…)
+- [x] Définir les types TypeScript pour toutes les formes SVG (ellipse, cercle, ligne, polygone, texte…)
 - [ ] Structurer le store Zustand pour :
   - L’undo/redo (état d’historique)
   - Les actions liées au document (import/export/new)

--- a/src/features/svg/types.ts
+++ b/src/features/svg/types.ts
@@ -1,4 +1,10 @@
-export type SvgShapeType = 'rect'
+export type SvgShapeType =
+  | 'rect'
+  | 'circle'
+  | 'ellipse'
+  | 'line'
+  | 'polygon'
+  | 'text'
 
 export interface SvgBaseShape {
   id: string
@@ -14,7 +20,40 @@ export interface SvgRect extends SvgBaseShape {
   height: number
 }
 
-export type SvgShape = SvgRect
+export interface SvgCircle extends SvgBaseShape {
+  type: 'circle'
+  radius: number
+}
+
+export interface SvgEllipse extends SvgBaseShape {
+  type: 'ellipse'
+  rx: number
+  ry: number
+}
+
+export interface SvgLine extends SvgBaseShape {
+  type: 'line'
+  x2: number
+  y2: number
+}
+
+export interface SvgPolygon extends SvgBaseShape {
+  type: 'polygon'
+  points: { x: number; y: number }[]
+}
+
+export interface SvgText extends SvgBaseShape {
+  type: 'text'
+  text: string
+}
+
+export type SvgShape =
+  | SvgRect
+  | SvgCircle
+  | SvgEllipse
+  | SvgLine
+  | SvgPolygon
+  | SvgText
 
 export interface SvgDocument {
   shapes: SvgShape[]


### PR DESCRIPTION
## Summary
- expand `SvgShapeType` to include more shape variants
- create interfaces for circle, ellipse, line, polygon and text
- mark TODO for defining SVG shape types as complete

## Testing
- `pnpm run format` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*

------
https://chatgpt.com/codex/tasks/task_e_68629e599db08325b4df030a9f36ab42