### PR TITLE
Implement history and document stores

### DIFF
--- a/docs/TODOLIST.md
+++ b/docs/TODOLIST.md
@@ -3,7 +3,7 @@
 ## 1. Structure des types et du store
 
 - [x] Définir les types TypeScript pour toutes les formes SVG (ellipse, cercle, ligne, polygone, texte…)
-- [ ] Structurer le store Zustand pour :
+- [x] Structurer le store Zustand pour :
   - L’undo/redo (état d’historique)
   - Les actions liées au document (import/export/new)
 

--- a/src/store/document.ts
+++ b/src/store/document.ts
@@ -1,0 +1,21 @@
+import { create } from 'zustand'
+import type { SvgDocument } from '../features/svg/types'
+
+export interface DocumentState {
+  document: SvgDocument
+}
+
+export interface DocumentActions {
+  newDocument: () => void
+  importDocument: (doc: SvgDocument) => void
+  exportDocument: () => string
+}
+
+const emptyDoc: SvgDocument = { shapes: [], selectedId: null }
+
+export const useDocumentStore = create<DocumentState & DocumentActions>((set, get) => ({
+  document: emptyDoc,
+  newDocument: () => set({ document: emptyDoc }),
+  importDocument: (doc) => set({ document: doc }),
+  exportDocument: () => JSON.stringify(get().document),
+}))

--- a/src/store/history.ts
+++ b/src/store/history.ts
@@ -1,0 +1,50 @@
+import { create } from 'zustand'
+import type { SvgDocument } from '../features/svg/types'
+
+export interface HistoryState {
+  past: SvgDocument[]
+  present: SvgDocument
+  future: SvgDocument[]
+}
+
+export interface HistoryActions {
+  undo: () => void
+  redo: () => void
+  record: (doc: SvgDocument) => void
+  reset: (doc?: SvgDocument) => void
+}
+
+const emptyDoc: SvgDocument = { shapes: [], selectedId: null }
+
+export const useHistoryStore = create<HistoryState & HistoryActions>((set) => ({
+  past: [],
+  present: emptyDoc,
+  future: [],
+  undo: () =>
+    set((state) => {
+      if (state.past.length === 0) return state
+      const previous = state.past[state.past.length - 1]
+      return {
+        past: state.past.slice(0, -1),
+        present: previous,
+        future: [state.present, ...state.future],
+      }
+    }),
+  redo: () =>
+    set((state) => {
+      if (state.future.length === 0) return state
+      const next = state.future[0]
+      return {
+        past: [...state.past, state.present],
+        present: next,
+        future: state.future.slice(1),
+      }
+    }),
+  record: (doc) =>
+    set((state) => ({
+      past: [...state.past, state.present],
+      present: doc,
+      future: [],
+    })),
+  reset: (doc = emptyDoc) => set({ past: [], present: doc, future: [] }),
+}))


### PR DESCRIPTION
## Summary
- add Zustand store for history state handling undo/redo
- add Zustand store for document actions (new/import/export)
- mark TODO item as complete

## Testing
- `pnpm run format` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*

------
https://chatgpt.com/codex/tasks/task_e_6862a26d8d508325976f9ccf39b92508