### PR TITLE
Add grid toggle

### DIFF
--- a/docs/TODOLIST.md
+++ b/docs/TODOLIST.md
@@ -11,7 +11,7 @@
 
 ## 2. Rendu du canevas SVG
 
-- [ ] Afficher la grille de fond (optionnelle, toggle)
+ - [x] Afficher la grille de fond (optionnelle, toggle)
 - [ ] Ajouter le zoom et le pan (déplacement du canevas)
 
 ---

--- a/docs/TODOLIST.md
+++ b/docs/TODOLIST.md
@@ -2,7 +2,8 @@
 
 ## 1. Structure des types et du store
 
-- [x] Définir les types TypeScript pour toutes les formes SVG (ellipse, cercle, ligne, polygone, texte…)
+- [x] Définir les types TypeScript pour toutes les formes SVG (ellipse, cercle,
+      ligne, polygone, texte…)
 - [x] Structurer le store Zustand pour :
   - L’undo/redo (état d’historique)
   - Les actions liées au document (import/export/new)
@@ -11,7 +12,7 @@
 
 ## 2. Rendu du canevas SVG
 
- - [x] Afficher la grille de fond (optionnelle, toggle)
+- [x] Afficher la grille de fond (optionnelle, toggle)
 - [ ] Ajouter le zoom et le pan (déplacement du canevas)
 
 ---
@@ -32,8 +33,10 @@
 
 ## 4. Panneau de propriétés
 
-- [ ] Affichage dynamique des propriétés selon le type de forme (ellipse, cercle, ligne, polygone, texte…)
-- [ ] Édition des propriétés avancées : opacité, bordure, texte/mise en forme pour le texte SVG, etc.
+- [ ] Affichage dynamique des propriétés selon le type de forme (ellipse,
+      cercle, ligne, polygone, texte…)
+- [ ] Édition des propriétés avancées : opacité, bordure, texte/mise en forme
+      pour le texte SVG, etc.
 
 ---
 
@@ -63,14 +66,16 @@
 ## 7. Copier/Coller et duplication
 
 - [ ] Copier/coller interne (Ctrl+C/Ctrl+V sur les formes)
-- [ ] Copier/coller SVG (exporter code SVG d’une forme/canevas, import par collage)
+- [ ] Copier/coller SVG (exporter code SVG d’une forme/canevas, import par
+      collage)
 - [ ] Duplication rapide d’une forme
 
 ---
 
 ## 8. Fonctions avancées de mise en page
 
-- [ ] Alignement et distribution des formes sélectionnées (gauche, droite, centre, haut, bas, espacement égal, etc.)
+- [ ] Alignement et distribution des formes sélectionnées (gauche, droite,
+      centre, haut, bas, espacement égal, etc.)
 - [ ] Guides et grille magnétique :
   - Affichage optionnel des guides
   - Snap sur grille/guides
@@ -114,3 +119,8 @@
 - [ ] Export PNG/PDF/JPEG (via canvas ou serveur)
 - [ ] Publication directe (GitHub Pages, partage de lien)
 - [ ] PWA / mode déconnecté
+
+## 13. Misc
+
+- [ ] Eviter les Cumulative Layout Shift pour les boutons. Faire que les boutons
+      dans le header soit a largeur fixe.

--- a/src/features/svg/SvgCanvas.tsx
+++ b/src/features/svg/SvgCanvas.tsx
@@ -5,6 +5,7 @@ export default function SvgCanvas() {
   const shapes = useSvgStore((s) => s.shapes)
   const selectedId = useSvgStore((s) => s.selectedId)
   const selectShape = useSvgStore((s) => s.selectShape)
+  const showGrid = useSvgStore((s) => s.showGrid)
 
   return (
     <svg
@@ -13,6 +14,16 @@ export default function SvgCanvas() {
       className="border border-gray-300 bg-gray-100"
       tabIndex={0}
     >
+      {showGrid && (
+        <>
+          <defs>
+            <pattern id="grid" width="20" height="20" patternUnits="userSpaceOnUse">
+              <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#d1d5db" strokeWidth="0.5" />
+            </pattern>
+          </defs>
+          <rect width="100%" height="100%" fill="url(#grid)" />
+        </>
+      )}
       {shapes.map((shape) => {
         if (shape.type === 'rect') {
           const rect = shape as SvgRect

--- a/src/features/svg/Toolbar.tsx
+++ b/src/features/svg/Toolbar.tsx
@@ -4,6 +4,8 @@ export default function Toolbar() {
   const addRect = useSvgStore((s) => s.addRect)
   const removeSelected = useSvgStore((s) => s.removeSelected)
   const selectedId = useSvgStore((s) => s.selectedId)
+  const toggleGrid = useSvgStore((s) => s.toggleGrid)
+  const showGrid = useSvgStore((s) => s.showGrid)
 
   return (
     <div className="flex gap-2">
@@ -19,6 +21,12 @@ export default function Toolbar() {
         disabled={!selectedId}
       >
         Supprimer la sélection
+      </button>
+      <button
+        className="rounded bg-gray-200 px-2 py-1 hover:bg-gray-300"
+        onClick={toggleGrid}
+      >
+        {showGrid ? 'Masquer' : 'Afficher'} la grille
       </button>
     </div>
   )

--- a/src/features/svg/store.ts
+++ b/src/features/svg/store.ts
@@ -1,11 +1,16 @@
 import { create } from 'zustand'
 import type { SvgDocument, SvgShape, SvgRect } from './types'
 
+interface SvgUiState {
+  showGrid: boolean
+}
+
 type SvgActions = {
   addRect: () => void
   selectShape: (id: string | null) => void
   removeSelected: () => void
   updateShape: (id: string, patch: Partial<SvgShape>) => void // Ajout
+  toggleGrid: () => void
 }
 
 const initialDoc: SvgDocument = {
@@ -13,8 +18,9 @@ const initialDoc: SvgDocument = {
   selectedId: null,
 }
 
-export const useSvgStore = create<SvgDocument & SvgActions>((set, get) => ({
+export const useSvgStore = create<SvgDocument & SvgUiState & SvgActions>((set, get) => ({
   ...initialDoc,
+  showGrid: false,
   addRect: () => {
     const newRect: SvgRect = {
       id: crypto.randomUUID(),
@@ -44,4 +50,5 @@ export const useSvgStore = create<SvgDocument & SvgActions>((set, get) => ({
       shapes: state.shapes.map((s) => (s.id === id ? { ...s, ...patch } : s)),
     }))
   },
+  toggleGrid: () => set((state) => ({ showGrid: !state.showGrid })),
 }))


### PR DESCRIPTION
## Summary
- show an optional background grid on the SVG canvas
- add a toolbar button to toggle the grid
- store the toggle state in the SVG store
- update todo list

## Testing
- `pnpm run format` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*

------
https://chatgpt.com/codex/tasks/task_e_6862a5b2649083259c89789052b4e034