### PR TITLE
Add zoom fit controls

### DIFF
--- a/docs/TODOLIST.md
+++ b/docs/TODOLIST.md
@@ -14,7 +14,7 @@
 
 - [x] Afficher la grille de fond (optionnelle, toggle)
 - [x] Ajouter le zoom et le pan (déplacement du canevas)
-- [ ] Afficher le niveau de zoom dans la barre d'outils
+- [x] Afficher le niveau de zoom dans la barre d'outils
 
 ---
 
@@ -130,7 +130,7 @@
       zoom et dérange l'utilisateur. Le centre du zoom devrait être la souris.
       Si on zoome avec le bouton, le centre du zoom devrait etre le centre du
       canvas.
-- [ ] Faire un bouton pour remettre le Zoom a 100% (avec raccourci clavier
+- [x] Faire un bouton pour remettre le Zoom a 100% (avec raccourci clavier
       Ctrl+0). Faire un deuxieme bouton pour mettre le zoom le plus élevé mais
       de facon a ce que l'utilisateur voit tous les objets dans le canvas (Zoom
       to fit) (avec raccourci clavier Shift+1). Faire un troisieme bouton pour

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,48 @@
+import { useEffect } from 'react'
 import Toolbar from './features/svg/Toolbar'
 import SvgCanvas from './features/svg/SvgCanvas'
 import ShapePropertiesPanel from './features/svg/ShapePropertiesPanel'
+import { useSvgStore } from './features/svg/store'
+import { computeFitView, getShapeBounds, getShapesBounds } from './features/svg/utils'
 
 export default function App() {
+  const shapes = useSvgStore((s) => s.shapes)
+  const selectedId = useSvgStore((s) => s.selectedId)
+  const setZoom = useSvgStore((s) => s.setZoom)
+  const setPan = useSvgStore((s) => s.setPan)
+
+  const selectedShape = shapes.find((s) => s.id === selectedId) || null
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.key === '0') {
+        e.preventDefault()
+        setZoom(1)
+        setPan({ x: 0, y: 0 })
+      } else if (e.shiftKey && e.key === '1') {
+        e.preventDefault()
+        if (shapes.length > 0) {
+          const { zoom, pan } = computeFitView(getShapesBounds(shapes), 400, 300)
+          setZoom(zoom)
+          setPan(pan)
+        }
+      } else if (e.shiftKey && e.key === '2') {
+        if (selectedShape) {
+          e.preventDefault()
+          const { zoom, pan } = computeFitView(
+            getShapeBounds(selectedShape),
+            400,
+            300,
+          )
+          setZoom(zoom)
+          setPan(pan)
+        }
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [shapes, selectedShape, setZoom, setPan])
+
   return (
     <div className="flex min-h-screen flex-col bg-gray-50">
       <header className="flex items-center justify-between bg-white p-6 shadow">

--- a/src/features/svg/Toolbar.tsx
+++ b/src/features/svg/Toolbar.tsx
@@ -1,5 +1,5 @@
 import { useSvgStore } from './store'
-import { applyZoom } from './utils'
+import { applyZoom, computeFitView, getShapeBounds, getShapesBounds } from './utils'
 
 export default function Toolbar() {
   const addRect = useSvgStore((s) => s.addRect)
@@ -11,6 +11,9 @@ export default function Toolbar() {
   const setZoom = useSvgStore((s) => s.setZoom)
   const pan = useSvgStore((s) => s.pan)
   const setPan = useSvgStore((s) => s.setPan)
+  const shapes = useSvgStore((s) => s.shapes)
+
+  const selectedShape = shapes.find((s) => s.id === selectedId) || null
 
   return (
     <div className="flex gap-2">
@@ -58,6 +61,46 @@ export default function Toolbar() {
         }}
       >
         Zoom -
+      </button>
+      <button
+        className="rounded bg-gray-200 px-2 py-1 hover:bg-gray-300"
+        onClick={() => {
+          setZoom(1)
+          setPan({ x: 0, y: 0 })
+        }}
+      >
+        Zoom 100%
+      </button>
+      <button
+        className="rounded bg-gray-200 px-2 py-1 hover:bg-gray-300"
+        onClick={() => {
+          if (shapes.length === 0) return
+          const { zoom: z, pan: p } = computeFitView(
+            getShapesBounds(shapes),
+            400,
+            300,
+          )
+          setZoom(z)
+          setPan(p)
+        }}
+      >
+        Tout voir
+      </button>
+      <button
+        className="rounded bg-gray-200 px-2 py-1 hover:bg-gray-300"
+        onClick={() => {
+          if (!selectedShape) return
+          const { zoom: z, pan: p } = computeFitView(
+            getShapeBounds(selectedShape),
+            400,
+            300,
+          )
+          setZoom(z)
+          setPan(p)
+        }}
+        disabled={!selectedShape}
+      >
+        Voir sélection
       </button>
       <span className="flex items-center text-sm text-gray-600">
         {Math.round(zoom * 100)}%

--- a/src/features/svg/utils.ts
+++ b/src/features/svg/utils.ts
@@ -15,3 +15,75 @@ export function applyZoom(
     },
   }
 }
+
+export interface Bounds {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export function getShapeBounds(shape: import('./types').SvgShape): Bounds {
+  switch (shape.type) {
+    case 'rect':
+      return { x: shape.x, y: shape.y, width: shape.width, height: shape.height }
+    case 'circle':
+      return {
+        x: shape.x - shape.radius,
+        y: shape.y - shape.radius,
+        width: shape.radius * 2,
+        height: shape.radius * 2,
+      }
+    case 'ellipse':
+      return {
+        x: shape.x - shape.rx,
+        y: shape.y - shape.ry,
+        width: shape.rx * 2,
+        height: shape.ry * 2,
+      }
+    case 'line':
+      return {
+        x: Math.min(shape.x, shape.x2),
+        y: Math.min(shape.y, shape.y2),
+        width: Math.abs(shape.x2 - shape.x) || 1,
+        height: Math.abs(shape.y2 - shape.y) || 1,
+      }
+    case 'polygon': {
+      const xs = shape.points.map((p) => p.x)
+      const ys = shape.points.map((p) => p.y)
+      const minX = Math.min(...xs)
+      const maxX = Math.max(...xs)
+      const minY = Math.min(...ys)
+      const maxY = Math.max(...ys)
+      return { x: minX, y: minY, width: maxX - minX, height: maxY - minY }
+    }
+    case 'text':
+      // Approximate text as a 0x0 box for now
+      return { x: shape.x, y: shape.y, width: 1, height: 1 }
+    default:
+      return { x: 0, y: 0, width: 1, height: 1 }
+  }
+}
+
+export function getShapesBounds(shapes: import('./types').SvgShape[]): Bounds {
+  if (shapes.length === 0) {
+    return { x: 0, y: 0, width: 1, height: 1 }
+  }
+  const bounds = shapes.map(getShapeBounds)
+  const minX = Math.min(...bounds.map((b) => b.x))
+  const minY = Math.min(...bounds.map((b) => b.y))
+  const maxX = Math.max(...bounds.map((b) => b.x + b.width))
+  const maxY = Math.max(...bounds.map((b) => b.y + b.height))
+  return { x: minX, y: minY, width: maxX - minX, height: maxY - minY }
+}
+
+export function computeFitView(bounds: Bounds, w: number, h: number) {
+  const padding = 20
+  const bw = bounds.width + padding * 2
+  const bh = bounds.height + padding * 2
+  const zoom = Math.min(5, Math.min(w / bw, h / bh))
+  const cx = bounds.x + bounds.width / 2
+  const cy = bounds.y + bounds.height / 2
+  const pan = { x: w / 2 - cx * zoom, y: h / 2 - cy * zoom }
+  return { zoom, pan }
+}


### PR DESCRIPTION
## Summary
- add utilities to compute bounds and fit view
- implement keyboard shortcuts for zooming
- add buttons for zoom reset, fit, and fit selection
- mark TODO items as complete

## Testing
- `pnpm run format` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*
- `pnpm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6863afc145cc8325af62b9326de9ae66