### PR TITLE
Add shape buttons

### DIFF
--- a/docs/TODOLIST.md
+++ b/docs/TODOLIST.md
@@ -20,7 +20,7 @@
 
 ## 3. Ajout et gestion des formes
 
-- [ ] Ajouter les boutons d’ajout pour ellipse, cercle, ligne, polygone, texte
+- [x] Ajouter les boutons d’ajout pour ellipse, cercle, ligne, polygone, texte
 - [ ] Permettre la sélection multiple (Maj+clic, rectangle de sélection)
 - [ ] Permettre l’ordre d’empilement (monter/descendre dans la pile)
 - [ ] Permettre la manipulation directe (drag, resize, rotate) :

--- a/src/features/svg/SvgCanvas.tsx
+++ b/src/features/svg/SvgCanvas.tsx
@@ -1,5 +1,12 @@
 import { useSvgStore } from './store'
-import type { SvgRect } from './types'
+import type {
+  SvgRect,
+  SvgCircle,
+  SvgEllipse,
+  SvgLine,
+  SvgPolygon,
+  SvgText,
+} from './types'
 import { useRef, useState } from 'react'
 import { applyZoom } from './utils'
 
@@ -66,32 +73,125 @@ export default function SvgCanvas() {
         {showGrid && (
           <>
             <defs>
-              <pattern id="grid" width="20" height="20" patternUnits="userSpaceOnUse">
-                <path d="M 20 0 L 0 0 0 20" fill="none" stroke="#d1d5db" strokeWidth="0.5" />
+              <pattern
+                id="grid"
+                width="20"
+                height="20"
+                patternUnits="userSpaceOnUse"
+              >
+                <path
+                  d="M 20 0 L 0 0 0 20"
+                  fill="none"
+                  stroke="#d1d5db"
+                  strokeWidth="0.5"
+                />
               </pattern>
             </defs>
             <rect width="100%" height="100%" fill="url(#grid)" />
           </>
         )}
         {shapes.map((shape) => {
-          if (shape.type === 'rect') {
-            const rect = shape as SvgRect
-            return (
-              <rect
-                key={rect.id}
-                x={rect.x}
-                y={rect.y}
-                width={rect.width}
-                height={rect.height}
-                fill={rect.fill}
-                stroke={rect.id === selectedId ? '#2563eb' : '#444'}
-                strokeWidth={rect.id === selectedId ? 3 : 1}
-                onClick={() => selectShape(rect.id)}
-                style={{ cursor: 'pointer' }}
-              />
-            )
+          switch (shape.type) {
+            case 'rect': {
+              const rect = shape as SvgRect
+              return (
+                <rect
+                  key={rect.id}
+                  x={rect.x}
+                  y={rect.y}
+                  width={rect.width}
+                  height={rect.height}
+                  fill={rect.fill}
+                  stroke={rect.id === selectedId ? '#2563eb' : '#444'}
+                  strokeWidth={rect.id === selectedId ? 3 : 1}
+                  onClick={() => selectShape(rect.id)}
+                  style={{ cursor: 'pointer' }}
+                />
+              )
+            }
+            case 'circle': {
+              const c = shape as SvgCircle
+              return (
+                <circle
+                  key={c.id}
+                  cx={c.x}
+                  cy={c.y}
+                  r={c.radius}
+                  fill={c.fill}
+                  stroke={c.id === selectedId ? '#2563eb' : '#444'}
+                  strokeWidth={c.id === selectedId ? 3 : 1}
+                  onClick={() => selectShape(c.id)}
+                  style={{ cursor: 'pointer' }}
+                />
+              )
+            }
+            case 'ellipse': {
+              const el = shape as SvgEllipse
+              return (
+                <ellipse
+                  key={el.id}
+                  cx={el.x}
+                  cy={el.y}
+                  rx={el.rx}
+                  ry={el.ry}
+                  fill={el.fill}
+                  stroke={el.id === selectedId ? '#2563eb' : '#444'}
+                  strokeWidth={el.id === selectedId ? 3 : 1}
+                  onClick={() => selectShape(el.id)}
+                  style={{ cursor: 'pointer' }}
+                />
+              )
+            }
+            case 'line': {
+              const ln = shape as SvgLine
+              return (
+                <line
+                  key={ln.id}
+                  x1={ln.x}
+                  y1={ln.y}
+                  x2={ln.x2}
+                  y2={ln.y2}
+                  stroke={ln.fill}
+                  strokeWidth={ln.id === selectedId ? 3 : 1}
+                  onClick={() => selectShape(ln.id)}
+                  style={{ cursor: 'pointer' }}
+                />
+              )
+            }
+            case 'polygon': {
+              const poly = shape as SvgPolygon
+              const points = poly.points.map((p) => `${p.x},${p.y}`).join(' ')
+              return (
+                <polygon
+                  key={poly.id}
+                  points={points}
+                  fill={poly.fill}
+                  stroke={poly.id === selectedId ? '#2563eb' : '#444'}
+                  strokeWidth={poly.id === selectedId ? 3 : 1}
+                  onClick={() => selectShape(poly.id)}
+                  style={{ cursor: 'pointer' }}
+                />
+              )
+            }
+            case 'text': {
+              const t = shape as SvgText
+              return (
+                <text
+                  key={t.id}
+                  x={t.x}
+                  y={t.y}
+                  fill={t.fill}
+                  fontSize="16"
+                  onClick={() => selectShape(t.id)}
+                  style={{ cursor: 'pointer' }}
+                >
+                  {t.text}
+                </text>
+              )
+            }
+            default:
+              return null
           }
-          return null
         })}
       </g>
     </svg>

--- a/src/features/svg/Toolbar.tsx
+++ b/src/features/svg/Toolbar.tsx
@@ -1,8 +1,18 @@
 import { useSvgStore } from './store'
-import { applyZoom, computeFitView, getShapeBounds, getShapesBounds } from './utils'
+import {
+  applyZoom,
+  computeFitView,
+  getShapeBounds,
+  getShapesBounds,
+} from './utils'
 
 export default function Toolbar() {
   const addRect = useSvgStore((s) => s.addRect)
+  const addCircle = useSvgStore((s) => s.addCircle)
+  const addEllipse = useSvgStore((s) => s.addEllipse)
+  const addLine = useSvgStore((s) => s.addLine)
+  const addPolygon = useSvgStore((s) => s.addPolygon)
+  const addText = useSvgStore((s) => s.addText)
   const removeSelected = useSvgStore((s) => s.removeSelected)
   const selectedId = useSvgStore((s) => s.selectedId)
   const toggleGrid = useSvgStore((s) => s.toggleGrid)
@@ -22,6 +32,36 @@ export default function Toolbar() {
         onClick={addRect}
       >
         Ajouter un rectangle
+      </button>
+      <button
+        className="rounded bg-yellow-400 px-2 py-1 hover:bg-yellow-500"
+        onClick={addCircle}
+      >
+        Ajouter un cercle
+      </button>
+      <button
+        className="rounded bg-yellow-400 px-2 py-1 hover:bg-yellow-500"
+        onClick={addEllipse}
+      >
+        Ajouter une ellipse
+      </button>
+      <button
+        className="rounded bg-yellow-400 px-2 py-1 hover:bg-yellow-500"
+        onClick={addLine}
+      >
+        Ajouter une ligne
+      </button>
+      <button
+        className="rounded bg-yellow-400 px-2 py-1 hover:bg-yellow-500"
+        onClick={addPolygon}
+      >
+        Ajouter un polygone
+      </button>
+      <button
+        className="rounded bg-yellow-400 px-2 py-1 hover:bg-yellow-500"
+        onClick={addText}
+      >
+        Ajouter un texte
       </button>
       <button
         className="rounded bg-red-500 px-2 py-1 text-white hover:bg-red-600 disabled:opacity-50"

--- a/src/features/svg/store.ts
+++ b/src/features/svg/store.ts
@@ -1,5 +1,14 @@
 import { create } from 'zustand'
-import type { SvgDocument, SvgShape, SvgRect } from './types'
+import type {
+  SvgDocument,
+  SvgShape,
+  SvgRect,
+  SvgCircle,
+  SvgEllipse,
+  SvgLine,
+  SvgPolygon,
+  SvgText,
+} from './types'
 
 interface SvgUiState {
   showGrid: boolean
@@ -9,6 +18,11 @@ interface SvgUiState {
 
 type SvgActions = {
   addRect: () => void
+  addCircle: () => void
+  addEllipse: () => void
+  addLine: () => void
+  addPolygon: () => void
+  addText: () => void
   selectShape: (id: string | null) => void
   removeSelected: () => void
   updateShape: (id: string, patch: Partial<SvgShape>) => void // Ajout
@@ -22,41 +36,121 @@ const initialDoc: SvgDocument = {
   selectedId: null,
 }
 
-export const useSvgStore = create<SvgDocument & SvgUiState & SvgActions>((set, get) => ({
-  ...initialDoc,
-  showGrid: false,
-  zoom: 1,
-  pan: { x: 0, y: 0 },
-  addRect: () => {
-    const newRect: SvgRect = {
-      id: crypto.randomUUID(),
-      type: 'rect',
-      x: 120 + Math.random() * 100,
-      y: 80 + Math.random() * 100,
-      width: 80,
-      height: 60,
-      fill: '#fbbf24',
-    }
-    set((state) => ({
-      shapes: [...state.shapes, newRect],
-      selectedId: newRect.id,
-    }))
-  },
-  selectShape: (id) => set({ selectedId: id }),
-  removeSelected: () => {
-    const { selectedId, shapes } = get()
-    if (!selectedId) return
-    set({
-      shapes: shapes.filter((s) => s.id !== selectedId),
-      selectedId: null,
-    })
-  },
-  updateShape: (id, patch) => {
-    set((state) => ({
-      shapes: state.shapes.map((s) => (s.id === id ? { ...s, ...patch } : s)),
-    }))
-  },
-  toggleGrid: () => set((state) => ({ showGrid: !state.showGrid })),
-  setZoom: (zoom) => set({ zoom }),
-  setPan: (pan) => set({ pan }),
-}))
+export const useSvgStore = create<SvgDocument & SvgUiState & SvgActions>(
+  (set, get) => ({
+    ...initialDoc,
+    showGrid: false,
+    zoom: 1,
+    pan: { x: 0, y: 0 },
+    addRect: () => {
+      const newRect: SvgRect = {
+        id: crypto.randomUUID(),
+        type: 'rect',
+        x: 120 + Math.random() * 100,
+        y: 80 + Math.random() * 100,
+        width: 80,
+        height: 60,
+        fill: '#fbbf24',
+      }
+      set((state) => ({
+        shapes: [...state.shapes, newRect],
+        selectedId: newRect.id,
+      }))
+    },
+    addCircle: () => {
+      const newCircle: SvgCircle = {
+        id: crypto.randomUUID(),
+        type: 'circle',
+        x: 150 + Math.random() * 100,
+        y: 100 + Math.random() * 100,
+        radius: 40,
+        fill: '#f87171',
+      }
+      set((state) => ({
+        shapes: [...state.shapes, newCircle],
+        selectedId: newCircle.id,
+      }))
+    },
+    addEllipse: () => {
+      const newEllipse: SvgEllipse = {
+        id: crypto.randomUUID(),
+        type: 'ellipse',
+        x: 160 + Math.random() * 100,
+        y: 90 + Math.random() * 100,
+        rx: 50,
+        ry: 30,
+        fill: '#34d399',
+      }
+      set((state) => ({
+        shapes: [...state.shapes, newEllipse],
+        selectedId: newEllipse.id,
+      }))
+    },
+    addLine: () => {
+      const newLine: SvgLine = {
+        id: crypto.randomUUID(),
+        type: 'line',
+        x: 120 + Math.random() * 100,
+        y: 120 + Math.random() * 100,
+        x2: 220 + Math.random() * 100,
+        y2: 170 + Math.random() * 100,
+        fill: '#000000',
+      }
+      set((state) => ({
+        shapes: [...state.shapes, newLine],
+        selectedId: newLine.id,
+      }))
+    },
+    addPolygon: () => {
+      const baseX = 150 + Math.random() * 100
+      const baseY = 120 + Math.random() * 100
+      const newPolygon: SvgPolygon = {
+        id: crypto.randomUUID(),
+        type: 'polygon',
+        x: baseX,
+        y: baseY,
+        points: [
+          { x: baseX, y: baseY - 40 },
+          { x: baseX - 40, y: baseY + 40 },
+          { x: baseX + 40, y: baseY + 40 },
+        ],
+        fill: '#a78bfa',
+      }
+      set((state) => ({
+        shapes: [...state.shapes, newPolygon],
+        selectedId: newPolygon.id,
+      }))
+    },
+    addText: () => {
+      const newText: SvgText = {
+        id: crypto.randomUUID(),
+        type: 'text',
+        x: 140 + Math.random() * 100,
+        y: 140 + Math.random() * 100,
+        text: 'Texte',
+        fill: '#1d4ed8',
+      }
+      set((state) => ({
+        shapes: [...state.shapes, newText],
+        selectedId: newText.id,
+      }))
+    },
+    selectShape: (id) => set({ selectedId: id }),
+    removeSelected: () => {
+      const { selectedId, shapes } = get()
+      if (!selectedId) return
+      set({
+        shapes: shapes.filter((s) => s.id !== selectedId),
+        selectedId: null,
+      })
+    },
+    updateShape: (id, patch) => {
+      set((state) => ({
+        shapes: state.shapes.map((s) => (s.id === id ? { ...s, ...patch } : s)),
+      }))
+    },
+    toggleGrid: () => set((state) => ({ showGrid: !state.showGrid })),
+    setZoom: (zoom) => set({ zoom }),
+    setPan: (pan) => set({ pan }),
+  }),
+)


### PR DESCRIPTION
## Summary
- add creation actions for circle, ellipse, line, polygon and text
- show these new shapes in the canvas
- expose new buttons in the toolbar
- mark TODO list item as done

## Testing
- `pnpm run format`

------
https://chatgpt.com/codex/tasks/task_e_6863d459f7848325a8665d27517d6766